### PR TITLE
Fixes from OpenZeppelin repository rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       $(function(){
         setTimeout(function(){
           $("#typed").typed({
-              strings: ['<br>[~]$ npm install zeppelin-solidity' ],
+              strings: ['<br>[~]$ npm install openzeppelin-solidity' ],
               typeSpeed: 5,
               backDelay: 500,
               loop: false,
@@ -71,7 +71,7 @@
       function fixedText1and2(){
         $('.terminal .typed-cursor').css("color", "black");
         setTimeout(function(){
-          document.getElementById('fixed-text').innerHTML = '</br> > zeppelin-solidity@1.2.0 install';
+          document.getElementById('fixed-text').innerHTML = '</br> > openzeppelin-solidity@1.2.0 install';
         }, 200);
         setTimeout(function(){
           document.getElementById('fixed-text2').innerHTML = '</br> > scripts/install.sh</br>';
@@ -108,7 +108,7 @@
 
         setTimeout(function(){
           $("#typed-vim").typed({
-            strings: ['<br>pragma solidity <span style="color: #FC1E70;">^^</span><span style="color: #AF7DFF;">0.4.11</span>;</br><span style="color: #FC1E70;">import</span> <span style="color: #E6DC6D;">"zeppelin-solidity/contracts/<br class="mobile-br"/><span class="mobile-br">&nbsp;</span>token/StandardToken.sol"</span>;</br></br>contract ExampleToken is StandardToken {</br><span class="terminal-padding">  string public name <span style="color: #FC1E70;">=</span> <span style="color: #E6DC6D;">"ExampleToken"</span>; </br></span><span class="terminal-padding">   string public symbol <span style="color: #FC1E70;">=</span><span style="color: #E6DC6D;"> "EGT"</span>;</br></span><span class="terminal-padding"> uint public decimals <span style="color: #FC1E70;">= </span><span style="color: #AF7DFF;">18</span>;</br></span><span class="terminal-padding"> uint public INITIAL_SUPPLY <span style="color: #FC1E70;">=</span><br class="mobile-br"/><span class="mobile-br">&nbsp;</span><span style="color: #AF7DFF;"> 10000</span> * (<span style="color: #AF7DFF;">10</span> ** decimals)</span>;</br></span><br class="desktop-br" /><span class="terminal-padding"> <span style="color: #60D9F1;">function</span><span style="color: #9AE407;"> ExampleToken</span>() {</br></span><span class="terminal-padding2">  totalSupply <span style="color: #FC1E70;">=</span> INITIAL_SUPPLY;</br>  </span><span class="terminal-padding2">balances[msg.sender] <span style="color: #FC1E70;">=</span> INITIAL_SUPPLY;</br></span><span class="terminal-padding">   }^500</br>}' ],
+            strings: ['<br>pragma solidity <span style="color: #FC1E70;">^^</span><span style="color: #AF7DFF;">0.4.11</span>;</br><span style="color: #FC1E70;">import</span> <span style="color: #E6DC6D;">"openzeppelin-solidity/contracts/<br class="mobile-br"/><span class="mobile-br">&nbsp;</span>token/StandardToken.sol"</span>;</br></br>contract ExampleToken is StandardToken {</br><span class="terminal-padding">  string public name <span style="color: #FC1E70;">=</span> <span style="color: #E6DC6D;">"ExampleToken"</span>; </br></span><span class="terminal-padding">   string public symbol <span style="color: #FC1E70;">=</span><span style="color: #E6DC6D;"> "EGT"</span>;</br></span><span class="terminal-padding"> uint public decimals <span style="color: #FC1E70;">= </span><span style="color: #AF7DFF;">18</span>;</br></span><span class="terminal-padding"> uint public INITIAL_SUPPLY <span style="color: #FC1E70;">=</span><br class="mobile-br"/><span class="mobile-br">&nbsp;</span><span style="color: #AF7DFF;"> 10000</span> * (<span style="color: #AF7DFF;">10</span> ** decimals)</span>;</br></span><br class="desktop-br" /><span class="terminal-padding"> <span style="color: #60D9F1;">function</span><span style="color: #9AE407;"> ExampleToken</span>() {</br></span><span class="terminal-padding2">  totalSupply <span style="color: #FC1E70;">=</span> INITIAL_SUPPLY;</br>  </span><span class="terminal-padding2">balances[msg.sender] <span style="color: #FC1E70;">=</span> INITIAL_SUPPLY;</br></span><span class="terminal-padding">   }^500</br>}' ],
             typeSpeed: 0,
             backDelay: 500,
             loop: false,
@@ -222,7 +222,7 @@
               <a href="https://slack.openzeppelin.org/" target="_blank" style="position:relative">Chat <span class="chat-circle"></span></a>
             </li>
             <li class="nav-li-hidden hidden-xs" id="nav-get-started">
-              <a href="https://github.com/OpenZeppelin/zeppelin-solidity" target="_blank" class="nav-btn-li-shown" id="main-cta"><span class="cta btn nav-btn-info" >Get Started</span></a>
+              <a href="https://github.com/OpenZeppelin/openzeppelin-solidity" target="_blank" class="nav-btn-li-shown" id="main-cta"><span class="cta btn nav-btn-info" >Get Started</span></a>
             </li>
           </ul>
         </div>
@@ -243,7 +243,7 @@
           </div>
           <div class="row">
             <div class="col-xs-12 col-sm-8 col-sm-offset-2 calltoaction">
-              <a href="https://github.com/OpenZeppelin/zeppelin-solidity" target="_blank" id="main-cta" class="cta btn btn-info">Get Started</a>
+              <a href="https://github.com/OpenZeppelin/openzeppelin-solidity" target="_blank" id="main-cta" class="cta btn btn-info">Get Started</a>
             </div>
           </div>
         </div>
@@ -333,7 +333,7 @@
               <img src="./img/modular.svg" alt="Payment"/>
               <h3>Modular approach</h3>
               <p class="explain-icon">Simple code, only basics. Easy collaboration and auditing.</p>
-              <p class="explain-icon-link"><a href="https://github.com/OpenZeppelin/zeppelin-solidity" target="_blank">Explore code > </a></p>
+              <p class="explain-icon-link"><a href="https://github.com/OpenZeppelin/openzeppelin-solidity" target="_blank">Explore code > </a></p>
             </div>
             <div class="col-xs-10 col-sm-4 col-sm-offset-0 col-xs-offset-1 feature-card">
               <img src="./img/open-source.svg" alt="Employee"/>
@@ -415,7 +415,7 @@
         </div>
         <div class="row">
           <div class="col-xs-12 col-sm-8 col-sm-offset-2 calltoaction">
-            <a href="https://github.com/OpenZeppelin/zeppelin-solidity" target="_blank" id="main-cta" class="cta btn btn-info">Get Started</a>
+            <a href="https://github.com/OpenZeppelin/openzeppelin-solidity" target="_blank" id="main-cta" class="cta btn btn-info">Get Started</a>
           </div>
         </div>
         <div class='gray-separator'>&nbsp;</div>
@@ -432,7 +432,7 @@
       <div class="right">
         <nav>
           <ul>
-            <li class="license-li"><a href="https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/LICENSE" target="_blank">OpenZeppelin License</a></li>
+            <li class="license-li"><a href="https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/LICENSE" target="_blank">OpenZeppelin License</a></li>
             <li><a href="mailto:contact@openzeppelin.org">contact@openzeppelin.org</a></li>
             <li class="bottom-li"><a href="mailto:security@openzeppelin.org">security@openzeppelin.org</a></li>
           </ul>


### PR DESCRIPTION
The repo name changed from `zeppelin-solidity` to `openzeppelin-solidity`, made changes to reflect this in the landing. 